### PR TITLE
fixed dependency versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,7 +22,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,9 @@ requirements:
 
   run:
     - python
-    - google-cloud-core >=0.28.0,<0.29dev
-    - google-api-core >=1.0.0,<2.0.0dev
-    - google-resumable-media >=0.2.1
+    - google-cloud-core >=0.29.0,<0.30dev
+    - google-api-core >=1.6.0,<2.0.0dev
+    - google-resumable-media >=0.3.1
 
 test:
   requires:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The dependency of google-cloud-bigquery is wrong in current version.
https://github.com/googleapis/google-cloud-python/blob/master/bigquery/setup.py
Because of this, google-cloud-bigquery conflicts with google-cloud-storage(1.14)!!
