### PR TITLE
Remove test restriction to Python 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -29,9 +29,8 @@ requirements:
     - google-resumable-media >=0.3.1
 
 test:
-  requires:
-    - python 3.6  # work around temporary protobuf issues
   imports:
+    - google.api_core
     - google.cloud.bigquery
 
 about:


### PR DESCRIPTION
Protobuf should now have 3.7 binaries on conda-forge.

Also, add tests for google.api_core, since that seems to be where imports tend
to fail.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Closes #15.